### PR TITLE
fix: correct draw_pixels placement when cel is not at origin (0,0)

### DIFF
--- a/pkg/aseprite/lua_drawing.go
+++ b/pkg/aseprite/lua_drawing.go
@@ -61,8 +61,20 @@ end
 
 app.transaction(function()
 	local cel = layer:cel(frame)
-	if not cel then
-		cel = spr:newCel(layer, frame)
+	if cel and cel.image then
+		-- Composite existing content into a full-canvas image at (0,0) so that
+		-- sprite coordinates match image coordinates for putPixel below. Without
+		-- this, Image:putPixel uses cel-local coordinates and pixels are offset
+		-- by the cel's position whenever content does not start at (0,0).
+		local full = Image(spr.width, spr.height, spr.colorMode)
+		full:drawImage(cel.image, cel.position)
+		cel.image = full
+		cel.position = Point(0, 0)
+	else
+		-- No cel yet (or nil image, e.g. a freshly added layer): create a
+		-- full-canvas cel WITH an image so putPixel has a valid target.
+		local full = Image(spr.width, spr.height, spr.colorMode)
+		cel = spr:newCel(layer, frame, full, Point(0, 0))
 	end
 
 	local img = cel.image

--- a/pkg/aseprite/lua_test.go
+++ b/pkg/aseprite/lua_test.go
@@ -168,6 +168,33 @@ func TestLuaGenerator_DrawPixels(t *testing.T) {
 	}
 }
 
+// TestLuaGenerator_DrawPixels_NormalizesCel verifies the generated script
+// normalizes the target cel to a full-canvas image at (0,0) before writing.
+//
+// Image:putPixel uses cel-LOCAL coordinates, so the script must guarantee the
+// cel covers the whole sprite at origin (0,0); otherwise pixels are offset by
+// the cel's position whenever the layer's content does not start at (0,0)
+// (e.g. after a shape tool trims the cel). This is a pure string check so it
+// runs without Aseprite — guarding the fix in CI, where the integration tests
+// (which require a real Aseprite install) do not run.
+func TestLuaGenerator_DrawPixels_NormalizesCel(t *testing.T) {
+	gen := NewLuaGenerator()
+	pixels := []Pixel{{Point: Point{X: 3, Y: 4}, Color: Color{R: 1, G: 2, B: 3, A: 255}}}
+	script := gen.DrawPixels("Layer 1", 1, pixels, false)
+
+	wants := []string{
+		"Image(spr.width, spr.height, spr.colorMode)", // full-canvas image
+		"full:drawImage(cel.image, cel.position)",     // preserve existing content
+		"cel.position = Point(0, 0)",                   // reposition existing cel to origin
+		"spr:newCel(layer, frame, full, Point(0, 0))", // new cel carries a full-canvas image
+	}
+	for _, w := range wants {
+		if !strings.Contains(script, w) {
+			t.Errorf("generated script missing %q; cel is not normalized to full-canvas at (0,0)", w)
+		}
+	}
+}
+
 func TestLuaGenerator_ExportSprite(t *testing.T) {
 	gen := NewLuaGenerator()
 

--- a/pkg/tools/drawing_pixels_after_shape_bug_test.go
+++ b/pkg/tools/drawing_pixels_after_shape_bug_test.go
@@ -1,0 +1,70 @@
+//go:build integration
+
+package tools
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/willibrandon/pixel-mcp/internal/testutil"
+	"github.com/willibrandon/pixel-mcp/pkg/aseprite"
+)
+
+// TestIntegration_DrawPixels_AfterShape_CelOffset reproduces the bug where
+// draw_pixels places pixels at the wrong coordinates once a shape tool has
+// caused the layer's cel to be trimmed to a non-(0,0) origin.
+//
+// A filled circle drawn in the middle of the canvas leaves the cel positioned
+// at the circle's bounding-box top-left (not the sprite origin). DrawPixels then
+// wrote with cel-LOCAL coordinates via Image:putPixel, so a pixel requested at
+// sprite (16,16) actually landed at (16 + cel.x, 16 + cel.y). This test asserts
+// the pixel ends up exactly where it was requested.
+func TestIntegration_DrawPixels_AfterShape_CelOffset(t *testing.T) {
+	cfg := testutil.LoadTestConfig(t)
+	client := aseprite.NewClient(cfg.AsepritePath, cfg.TempDir, 30*time.Second)
+	gen := aseprite.NewLuaGenerator()
+	ctx := context.Background()
+
+	spritePath := testutil.TempSpritePath(t, "test-pixels-after-shape.aseprite")
+	createScript := gen.CreateCanvas(32, 32, aseprite.ColorModeRGB, spritePath)
+	if _, err := client.ExecuteLua(ctx, createScript, ""); err != nil {
+		t.Fatalf("Failed to create canvas: %v", err)
+	}
+
+	// Draw a filled circle in the center. After save, Aseprite trims the cel to
+	// this content, so the cel origin becomes non-zero (≈(2,2) for r14 on 32px).
+	circleColor := aseprite.Color{R: 0, G: 170, B: 255, A: 255} // #00AAFF
+	circleScript := gen.DrawCircle("Layer 1", 1, 16, 16, 14, circleColor, true, false)
+	if _, err := client.ExecuteLua(ctx, circleScript, spritePath); err != nil {
+		t.Fatalf("Failed to draw circle: %v", err)
+	}
+
+	// Draw a single distinct pixel at a known sprite coordinate inside the circle.
+	dotColor := aseprite.Color{R: 255, G: 0, B: 0, A: 255} // #FF0000
+	pixels := []aseprite.Pixel{
+		{Point: aseprite.Point{X: 16, Y: 16}, Color: dotColor},
+	}
+	drawScript := gen.DrawPixels("Layer 1", 1, pixels, false)
+	if _, err := client.ExecuteLua(ctx, drawScript, spritePath); err != nil {
+		t.Fatalf("Failed to draw pixel: %v", err)
+	}
+
+	// The pixel must be exactly at sprite (16,16), not offset by the cel origin.
+	getScript := gen.GetPixels("Layer 1", 1, 16, 16, 1, 1)
+	output, err := client.ExecuteLua(ctx, getScript, spritePath)
+	if err != nil {
+		t.Fatalf("Failed to get pixels: %v", err)
+	}
+	got, err := testutil.ParsePixelData(output)
+	if err != nil {
+		t.Fatalf("Failed to parse pixel data: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 pixel for region (16,16,1,1), got %d", len(got))
+	}
+	if got[0].Color != "#FF0000FF" {
+		t.Errorf("BUG CONFIRMED: pixel at sprite (16,16) = %s, want #FF0000FF "+
+			"(draw_pixels offset by the cel origin)", got[0].Color)
+	}
+}

--- a/pkg/tools/drawing_pixels_outside_shape_bug_test.go
+++ b/pkg/tools/drawing_pixels_outside_shape_bug_test.go
@@ -1,0 +1,73 @@
+//go:build integration
+
+package tools
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/willibrandon/pixel-mcp/internal/testutil"
+	"github.com/willibrandon/pixel-mcp/pkg/aseprite"
+)
+
+// TestIntegration_DrawPixels_AfterShape_OutsideShapeBounds verifies that
+// draw_pixels can place a pixel anywhere on the sprite after a shape tool has
+// trimmed the cel to a non-(0,0), ASYMMETRIC origin — including a coordinate
+// OUTSIDE the shape's bounding box.
+//
+// This covers two facets the simple offset test does not:
+//   - asymmetric origin (x != y), proving both axes are handled independently
+//   - a pixel outside the trimmed cel, which the stock code dropped entirely
+//     (writing to cel-local coords that map elsewhere, leaving the requested
+//     coordinate transparent)
+func TestIntegration_DrawPixels_AfterShape_OutsideShapeBounds(t *testing.T) {
+	cfg := testutil.LoadTestConfig(t)
+	client := aseprite.NewClient(cfg.AsepritePath, cfg.TempDir, 30*time.Second)
+	gen := aseprite.NewLuaGenerator()
+	ctx := context.Background()
+
+	spritePath := testutil.TempSpritePath(t, "test-pixels-outside-shape.aseprite")
+	createScript := gen.CreateCanvas(32, 32, aseprite.ColorModeRGB, spritePath)
+	if _, err := client.ExecuteLua(ctx, createScript, ""); err != nil {
+		t.Fatalf("Failed to create canvas: %v", err)
+	}
+
+	// Asymmetric, inset rectangle -> cel origin becomes ≈(10,6) after trimming,
+	// so the x and y offsets differ.
+	rect := aseprite.Color{R: 0, G: 170, B: 255, A: 255} // #00AAFF
+	rectScript := gen.DrawRectangle("Layer 1", 1, 10, 6, 8, 8, rect, true, false)
+	if _, err := client.ExecuteLua(ctx, rectScript, spritePath); err != nil {
+		t.Fatalf("Failed to draw rectangle: %v", err)
+	}
+
+	// One pixel inside the rect, one OUTSIDE it near the top-left corner.
+	red := aseprite.Color{R: 255, G: 0, B: 0, A: 255}   // #FF0000 inside
+	green := aseprite.Color{R: 0, G: 255, B: 0, A: 255} // #00FF00 outside
+	pixels := []aseprite.Pixel{
+		{Point: aseprite.Point{X: 12, Y: 8}, Color: red},
+		{Point: aseprite.Point{X: 1, Y: 1}, Color: green},
+	}
+	drawScript := gen.DrawPixels("Layer 1", 1, pixels, false)
+	if _, err := client.ExecuteLua(ctx, drawScript, spritePath); err != nil {
+		t.Fatalf("Failed to draw pixels: %v", err)
+	}
+
+	assertPixel := func(x, y int, want string) {
+		t.Helper()
+		out, err := client.ExecuteLua(ctx, gen.GetPixels("Layer 1", 1, x, y, 1, 1), spritePath)
+		if err != nil {
+			t.Fatalf("get_pixels(%d,%d): %v", x, y, err)
+		}
+		got, err := testutil.ParsePixelData(out)
+		if err != nil {
+			t.Fatalf("parse (%d,%d): %v", x, y, err)
+		}
+		if len(got) != 1 || got[0].Color != want {
+			t.Errorf("BUG CONFIRMED: pixel (%d,%d) = %v, want %s", x, y, got, want)
+		}
+	}
+
+	assertPixel(12, 8, "#FF0000FF") // inside the shape: placed at the right spot
+	assertPixel(1, 1, "#00FF00FF")  // outside the shape: present, not lost
+}


### PR DESCRIPTION
Fixes #19.

## Problem

`draw_pixels` wrote to `cel.image` via `Image:putPixel` using **sprite** coordinates, but `putPixel` expects **cel-local** coordinates. Once a layer's cel is trimmed to a non-(0,0) origin (e.g. after any shape tool runs), every pixel was offset by the cel's position, and pixels outside the cel bounds were dropped. The shape tools are unaffected because they use `app.useTool`, which works in sprite space. `draw_pixels` on a newly added layer could also hit a nil cel image (`spr:newCel` 2-arg form).

## Fix

Normalize the target cel to a full-canvas image at (0,0) before writing (compositing any existing content first), so sprite coordinates equal image coordinates. This also gives a fresh cel a valid image. Aseprite re-trims the cel on save, so canvas dimensions and file size are unchanged.

```lua
local cel = layer:cel(frame)
if cel and cel.image then
    local full = Image(spr.width, spr.height, spr.colorMode)
    full:drawImage(cel.image, cel.position)
    cel.image = full
    cel.position = Point(0, 0)
else
    local full = Image(spr.width, spr.height, spr.colorMode)
    cel = spr:newCel(layer, frame, full, Point(0, 0))
end
local img = cel.image
-- existing putPixel loop unchanged
```

## Tests

- **`TestLuaGenerator_DrawPixels_NormalizesCel`** (unit, `pkg/aseprite/lua_test.go`) — asserts the generated script normalizes the cel to full-canvas at (0,0). Runs without Aseprite, so it guards the fix in CI (the integration tests require a real Aseprite install).
- **`TestIntegration_DrawPixels_AfterShape_CelOffset`** — circle, then a pixel at (16,16); asserts it lands exactly there.
- **`TestIntegration_DrawPixels_AfterShape_OutsideShapeBounds`** — asymmetric cel origin plus a pixel outside the shape's bbox (the lost-pixel case).

All three fail on `main` and pass with this change.

## Verification

```
go test ./...                      # untagged: ok
go test -race ./...                # ok
go test -tags=integration ./...    # ok (incl. existing draw_pixels cel tests)
```

## Notes

In **indexed** mode a new `Image` is filled with index 0 (the default transparent index), so transparency is preserved in the common case; if a sprite has a non-default `spr.transparentColor`, that should be honored — flagging in case you'd like a follow-up.