### PR TITLE
fix(indexed): resolve exact colors against the sprite's own palette

### DIFF
--- a/pkg/aseprite/lua_core.go
+++ b/pkg/aseprite/lua_core.go
@@ -54,29 +54,36 @@ func FormatColor(c Color) string {
 
 // FormatColorWithPalette formats a Color with optional palette snapping for img:putPixel.
 //
-// If usePalette is false, returns a direct Color constructor call.
-// If usePalette is true, wraps the color in snapToPaletteForPixel() to find the nearest palette color.
+// If usePalette is false, wraps the color in resolveExactPaletteColor() to require an exact
+// palette match on indexed sprites (errors otherwise) while passing RGB/grayscale colors through
+// unchanged. If usePalette is true, wraps the color in snapToPaletteForPixel() to find the
+// nearest palette color.
 //
-// The snapToPaletteForPixel function must be defined in the script (use GeneratePaletteSnapperHelper).
-// This is useful for palette-constrained pixel art to ensure all colors match the palette.
-// Returns palette index in indexed mode, pixel color in other modes.
+// The resolveExactPaletteColor function must be defined in the script when usePalette is false
+// (use ResolveExactPaletteColorHelper); snapToPaletteForPixel must be defined when usePalette is
+// true (use GeneratePaletteSnapperHelper). Returns palette index in indexed mode, pixel color in
+// other modes.
 func FormatColorWithPalette(c Color, usePalette bool) string {
 	if !usePalette {
-		return FormatColor(c)
+		return fmt.Sprintf("resolveExactPaletteColor(%d, %d, %d, %d)", c.R, c.G, c.B, c.A)
 	}
 	return fmt.Sprintf("snapToPaletteForPixel(%d, %d, %d, %d)", c.R, c.G, c.B, c.A)
 }
 
 // FormatColorWithPaletteForTool formats a Color with optional palette snapping for app.useTool.
 //
-// If usePalette is false, returns a direct Color constructor call.
-// If usePalette is true, wraps the color in snapToPaletteForTool() to find the nearest palette color.
+// If usePalette is false, wraps the color in resolveExactPaletteColor() to require an exact
+// palette match on indexed sprites (errors otherwise) while passing RGB/grayscale colors through
+// unchanged. If usePalette is true, wraps the color in snapToPaletteForTool() to find the nearest
+// palette color.
 //
-// The snapToPaletteForTool function must be defined in the script (use GeneratePaletteSnapperHelper).
-// Always returns a pixel color value suitable for app.useTool in all color modes.
+// The resolveExactPaletteColor function must be defined in the script when usePalette is false
+// (use ResolveExactPaletteColorHelper); snapToPaletteForTool must be defined when usePalette is
+// true (use GeneratePaletteSnapperHelper). Always returns a value suitable for app.useTool's
+// color field in all color modes.
 func FormatColorWithPaletteForTool(c Color, usePalette bool) string {
 	if !usePalette {
-		return FormatColor(c)
+		return fmt.Sprintf("resolveExactPaletteColor(%d, %d, %d, %d)", c.R, c.G, c.B, c.A)
 	}
 	return fmt.Sprintf("snapToPaletteForTool(%d, %d, %d, %d)", c.R, c.G, c.B, c.A)
 }
@@ -155,6 +162,59 @@ end
 -- Default snapToPalette for backwards compatibility (uses ForPixel variant)
 local function snapToPalette(r, g, b, a)
 	return snapToPaletteForPixel(r, g, b, a)
+end
+`
+}
+
+// ResolveExactPaletteColorHelper returns Lua code defining resolveExactPaletteColor,
+// a color-resolution helper for img:putPixel and app.useTool calls made with
+// usePalette=false (exact colors, no nearest-match snapping).
+//
+// On an indexed sprite, both img:putPixel and app.useTool expect a palette
+// index, not an arbitrary RGBA value. Passing a Color object directly works
+// when the sprite's palette was set earlier in the SAME Aseprite process, but
+// pixel-mcp runs each tool call as its own aseprite --batch invocation: the
+// palette is set in one process and the drawing happens in the next. In that
+// cross-process scenario, Aseprite's own Color-to-index resolution for
+// img:putPixel/app.useTool does not reliably match the sprite's actual,
+// correctly-loaded palette (confirmed by reading spr.palettes[1] back at the
+// point of failure) and silently resolves to an unrelated index instead,
+// corrupting the drawn color with no error.
+//
+// resolveExactPaletteColor works around this by resolving the color itself:
+// on an indexed sprite, a fully-transparent color (alpha 0, e.g. from a
+// "paint transparent" fill_area call) always resolves to spr.transparentColor
+// rather than a palette search, since transparency is a designated index, not
+// a color that is expected to exist in the palette. Any other color looks up
+// an EXACT match in the active palette and returns that index, erroring if
+// none exists (callers should pass use_palette=true to snap to the nearest
+// palette color instead). On a non-indexed sprite there is no palette to
+// resolve against, so it returns the raw color unchanged, preserving existing
+// RGB/grayscale behavior.
+func ResolveExactPaletteColorHelper() string {
+	return `
+-- Helper: Resolve an exact color for img:putPixel/app.useTool (usePalette=false)
+local function resolveExactPaletteColor(r, g, b, a)
+	local spr = app.activeSprite
+	if spr.colorMode ~= ColorMode.INDEXED then
+		return Color(r, g, b, a)
+	end
+
+	if a == 0 then
+		return spr.transparentColor
+	end
+
+	local palette = spr.palettes[1]
+	for i = 0, #palette - 1 do
+		local palColor = palette:getColor(i)
+		if palColor.red == r and palColor.green == g and palColor.blue == b and palColor.alpha == a then
+			return i
+		end
+	end
+
+	error(string.format(
+		"Color #%02X%02X%02X%02X has no exact match in the sprite's palette; use use_palette=true to snap to the nearest palette color",
+		r, g, b, a))
 end
 `
 }

--- a/pkg/aseprite/lua_drawing.go
+++ b/pkg/aseprite/lua_drawing.go
@@ -30,11 +30,14 @@ func (g *LuaGenerator) DrawPixels(layerName string, frameNumber int, pixels []Pi
 
 	escapedName := EscapeString(layerName)
 
-	// Add palette snapper helper if needed
+	// Add the color resolution helper: nearest-match snapping when requested,
+	// otherwise exact-match-or-error (see ResolveExactPaletteColorHelper).
 	if usePalette {
 		sb.WriteString(GeneratePaletteSnapperHelper())
-		sb.WriteString("\n")
+	} else {
+		sb.WriteString(ResolveExactPaletteColorHelper())
 	}
+	sb.WriteString("\n")
 
 	sb.WriteString(fmt.Sprintf(`local spr = app.activeSprite
 if not spr then
@@ -106,11 +109,14 @@ print("Pixels drawn successfully")`)
 func (g *LuaGenerator) DrawLine(layerName string, frameNumber int, x1, y1, x2, y2 int, color Color, thickness int, usePalette bool) string {
 	var sb strings.Builder
 
-	// Add palette snapper helper if needed
+	// Add the color resolution helper: nearest-match snapping when requested,
+	// otherwise exact-match-or-error (see ResolveExactPaletteColorHelper).
 	if usePalette {
 		sb.WriteString(GeneratePaletteSnapperHelper())
-		sb.WriteString("\n")
+	} else {
+		sb.WriteString(ResolveExactPaletteColorHelper())
 	}
+	sb.WriteString("\n")
 
 	escapedName := EscapeString(layerName)
 	sb.WriteString(fmt.Sprintf(`local spr = app.activeSprite
@@ -190,11 +196,14 @@ print("Line drawn successfully")`,
 func (g *LuaGenerator) DrawContour(layerName string, frameNumber int, points []Point, color Color, thickness int, closed bool, usePalette bool) string {
 	var sb strings.Builder
 
-	// Add palette snapper helper if needed
+	// Add the color resolution helper: nearest-match snapping when requested,
+	// otherwise exact-match-or-error (see ResolveExactPaletteColorHelper).
 	if usePalette {
 		sb.WriteString(GeneratePaletteSnapperHelper())
-		sb.WriteString("\n")
+	} else {
+		sb.WriteString(ResolveExactPaletteColorHelper())
 	}
+	sb.WriteString("\n")
 
 	escapedName := EscapeString(layerName)
 	sb.WriteString(fmt.Sprintf(`local spr = app.activeSprite
@@ -295,11 +304,14 @@ print("Contour drawn successfully")`)
 func (g *LuaGenerator) DrawRectangle(layerName string, frameNumber int, x, y, width, height int, color Color, filled bool, usePalette bool) string {
 	var sb strings.Builder
 
-	// Add palette snapper helper if needed
+	// Add the color resolution helper: nearest-match snapping when requested,
+	// otherwise exact-match-or-error (see ResolveExactPaletteColorHelper).
 	if usePalette {
 		sb.WriteString(GeneratePaletteSnapperHelper())
-		sb.WriteString("\n")
+	} else {
+		sb.WriteString(ResolveExactPaletteColorHelper())
 	}
+	sb.WriteString("\n")
 
 	escapedName := EscapeString(layerName)
 	tool := "rectangle"
@@ -379,11 +391,14 @@ print("Rectangle drawn successfully")`,
 func (g *LuaGenerator) DrawCircle(layerName string, frameNumber int, centerX, centerY, radius int, color Color, filled bool, usePalette bool) string {
 	var sb strings.Builder
 
-	// Add palette snapper helper if needed
+	// Add the color resolution helper: nearest-match snapping when requested,
+	// otherwise exact-match-or-error (see ResolveExactPaletteColorHelper).
 	if usePalette {
 		sb.WriteString(GeneratePaletteSnapperHelper())
-		sb.WriteString("\n")
+	} else {
+		sb.WriteString(ResolveExactPaletteColorHelper())
 	}
+	sb.WriteString("\n")
 
 	escapedName := EscapeString(layerName)
 	tool := "ellipse"
@@ -469,11 +484,14 @@ print("Circle drawn successfully")`,
 func (g *LuaGenerator) FillArea(layerName string, frameNumber int, x, y int, color Color, tolerance int, usePalette bool) string {
 	var sb strings.Builder
 
-	// Add palette snapper helper if needed
+	// Add the color resolution helper: nearest-match snapping when requested,
+	// otherwise exact-match-or-error (see ResolveExactPaletteColorHelper).
 	if usePalette {
 		sb.WriteString(GeneratePaletteSnapperHelper())
-		sb.WriteString("\n")
+	} else {
+		sb.WriteString(ResolveExactPaletteColorHelper())
 	}
+	sb.WriteString("\n")
 
 	escapedName := EscapeString(layerName)
 	sb.WriteString(fmt.Sprintf(`local spr = app.activeSprite

--- a/pkg/aseprite/lua_palette_test.go
+++ b/pkg/aseprite/lua_palette_test.go
@@ -8,7 +8,7 @@ import (
 func TestFormatColorWithPalette_NoPalette(t *testing.T) {
 	color := Color{R: 255, G: 128, B: 64, A: 255}
 	result := FormatColorWithPalette(color, false)
-	expected := "Color(255, 128, 64, 255)"
+	expected := "resolveExactPaletteColor(255, 128, 64, 255)"
 	if result != expected {
 		t.Errorf("FormatColorWithPalette(usePalette=false) = %s, want %s", result, expected)
 	}

--- a/pkg/aseprite/lua_test.go
+++ b/pkg/aseprite/lua_test.go
@@ -159,11 +159,11 @@ func TestLuaGenerator_DrawPixels(t *testing.T) {
 		t.Error("script missing layer iteration")
 	}
 
-	if !strings.Contains(script, "img:putPixel(0, 0, Color(255, 0, 0, 255))") {
+	if !strings.Contains(script, "img:putPixel(0, 0, resolveExactPaletteColor(255, 0, 0, 255))") {
 		t.Error("script missing first pixel")
 	}
 
-	if !strings.Contains(script, "img:putPixel(1, 1, Color(0, 255, 0, 255))") {
+	if !strings.Contains(script, "img:putPixel(1, 1, resolveExactPaletteColor(0, 255, 0, 255))") {
 		t.Error("script missing second pixel")
 	}
 }

--- a/pkg/tools/exact_palette_color_indexed_mode_bug_test.go
+++ b/pkg/tools/exact_palette_color_indexed_mode_bug_test.go
@@ -1,0 +1,111 @@
+//go:build integration
+// +build integration
+
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/willibrandon/pixel-mcp/internal/testutil"
+	"github.com/willibrandon/pixel-mcp/pkg/aseprite"
+)
+
+// TestIntegration_IndexedMode_ExactColorResolution tests that drawing an exact
+// palette color (usePalette=false) on an indexed sprite resolves to the right
+// palette index, even though the palette was set in a PREVIOUS aseprite
+// process (pixel-mcp runs one process per tool call, so this is the normal
+// case, not an edge case).
+//
+// ROOT CAUSE: on an indexed sprite, img:putPixel and app.useTool both expect
+// a palette index. Given a raw Color object instead, Aseprite resolves it to
+// an index using an internal color cache that is only correctly populated
+// when the palette was set earlier in the SAME process. When the palette was
+// set in an earlier process and the sprite is reopened fresh (exactly how
+// every pixel-mcp tool call works), that resolution silently returns an
+// unrelated index, even though spr.palettes[1] reads back the correct,
+// expected palette when inspected directly. The result reads back as the
+// wrong color, or as transparent if the resolved index happens to be out of
+// the palette's range.
+//
+// FIX: resolveExactPaletteColor (pkg/aseprite/lua_core.go) looks up the exact
+// index itself by reading the sprite's actual active palette at Lua runtime,
+// bypassing Aseprite's unreliable internal resolution entirely.
+func TestIntegration_IndexedMode_ExactColorResolution(t *testing.T) {
+	cfg := testutil.LoadTestConfig(t)
+	client := aseprite.NewClient(cfg.AsepritePath, cfg.TempDir, 30*time.Second)
+	gen := aseprite.NewLuaGenerator()
+	ctx := context.Background()
+
+	// 4-color palette, set in its own process (as create_canvas + set_palette
+	// always are via the real MCP tools).
+	newIndexedSprite := func(t *testing.T, name string) string {
+		t.Helper()
+		spritePath := testutil.TempSpritePath(t, name)
+		createScript := gen.CreateCanvas(32, 32, aseprite.ColorModeIndexed, spritePath)
+		if _, err := client.ExecuteLua(ctx, createScript, ""); err != nil {
+			t.Fatalf("Failed to create canvas: %v", err)
+		}
+		setPaletteScript := gen.SetPalette([]string{
+			"#FF0000FF", // 0: RED
+			"#00FF00FF", // 1: GREEN
+			"#0000FFFF", // 2: BLUE
+			"#FFFF00FF", // 3: YELLOW
+		})
+		if _, err := client.ExecuteLua(ctx, setPaletteScript, spritePath); err != nil {
+			t.Fatalf("Failed to set palette: %v", err)
+		}
+		return spritePath
+	}
+
+	assertPixel := func(t *testing.T, spritePath string, x, y int, want string) {
+		t.Helper()
+		out, err := client.ExecuteLua(ctx, gen.GetPixels("Layer 1", 1, x, y, 1, 1), spritePath)
+		if err != nil {
+			t.Fatalf("get_pixels(%d,%d): %v", x, y, err)
+		}
+		got, err := testutil.ParsePixelData(out)
+		if err != nil {
+			t.Fatalf("parse (%d,%d): %v", x, y, err)
+		}
+		if len(got) != 1 || got[0].Color != want {
+			t.Errorf("BUG CONFIRMED: pixel (%d,%d) = %v, want %s", x, y, got, want)
+		}
+	}
+
+	t.Run("DrawRectangle_ExactMatch", func(t *testing.T) {
+		spritePath := newIndexedSprite(t, "test-exact-color-rect.aseprite")
+		green := aseprite.Color{R: 0, G: 255, B: 0, A: 255}
+		rectScript := gen.DrawRectangle("Layer 1", 1, 0, 0, 4, 4, green, true, false)
+		if _, err := client.ExecuteLua(ctx, rectScript, spritePath); err != nil {
+			t.Fatalf("Failed to draw rectangle: %v", err)
+		}
+		assertPixel(t, spritePath, 1, 1, "#00FF00FF")
+	})
+
+	t.Run("DrawPixels_ExactMatch", func(t *testing.T) {
+		spritePath := newIndexedSprite(t, "test-exact-color-pixels.aseprite")
+		blue := aseprite.Color{R: 0, G: 0, B: 255, A: 255}
+		pixels := []aseprite.Pixel{{Point: aseprite.Point{X: 5, Y: 5}, Color: blue}}
+		drawScript := gen.DrawPixels("Layer 1", 1, pixels, false)
+		if _, err := client.ExecuteLua(ctx, drawScript, spritePath); err != nil {
+			t.Fatalf("Failed to draw pixels: %v", err)
+		}
+		assertPixel(t, spritePath, 5, 5, "#0000FFFF")
+	})
+
+	t.Run("NoExactMatch_Errors", func(t *testing.T) {
+		spritePath := newIndexedSprite(t, "test-exact-color-no-match.aseprite")
+		purple := aseprite.Color{R: 128, G: 0, B: 128, A: 255} // not in the 4-color palette
+		rectScript := gen.DrawRectangle("Layer 1", 1, 0, 0, 4, 4, purple, true, false)
+		_, err := client.ExecuteLua(ctx, rectScript, spritePath)
+		if err == nil {
+			t.Fatal("expected an error for a color with no exact palette match, got nil")
+		}
+		if !strings.Contains(err.Error(), "has no exact match in the sprite's palette") {
+			t.Errorf("expected a no-exact-match error, got: %v", err)
+		}
+	})
+}

--- a/pkg/tools/palette_integration_test.go
+++ b/pkg/tools/palette_integration_test.go
@@ -238,8 +238,9 @@ func TestIntegration_SetPalette_ThenApplyShading(t *testing.T) {
 		t.Fatalf("Failed to set palette: %v", err)
 	}
 
-	// Step 2: Draw a circle with mid-tone
-	circleScript := gen.DrawCircle("Layer 1", 1, 32, 32, 25, aseprite.Color{R: 195, G: 87, B: 54, A: 255}, true, false)
+	// Step 2: Draw a circle with an approximate mid-tone, snapped to the locked
+	// palette (this color is not one of the 16 exact palette entries).
+	circleScript := gen.DrawCircle("Layer 1", 1, 32, 32, 25, aseprite.Color{R: 195, G: 87, B: 54, A: 255}, true, true)
 	_, err = client.ExecuteLua(ctx, circleScript, spritePath)
 	if err != nil {
 		t.Fatalf("Failed to draw circle: %v", err)


### PR DESCRIPTION
## Summary

Fixes a second, independent indexed-color-mode bug found while using the `pixel-plugin` Claude Code plugin (which bundles this server) for a game project: `img:putPixel`/`app.useTool` calls made with `use_palette=false` (exact colors, the default) silently draw the wrong pixel on an indexed sprite, with no error.

## Root cause

On an indexed sprite, both `img:putPixel` and `app.useTool` expect a palette index, not an arbitrary RGBA value. Passing a `Color` object directly resolves correctly when the sprite's palette was set earlier in the SAME Aseprite process. But every pixel-mcp tool call is its own `aseprite --batch` invocation: the palette is set in one process (`set_palette`) and drawing happens in the next (`draw_rectangle`, etc).

In that cross-process scenario (the normal case for every real tool call), Aseprite's own Color-to-index resolution for `img:putPixel`/`app.useTool` does not reliably match the sprite's actual, correctly-loaded palette. I confirmed this by reading `spr.palettes[1]` back at the point of failure: the palette is exactly right, but the index Aseprite picks for the requested RGBA is unrelated to it. The result silently corrupts the drawn color (in one repro, a raw RGBA that exactly equals the palette's index 3 resolved to index 8 instead, which was out of a 4-color palette's range and therefore read back as fully transparent).

Isolated with a minimal repro directly against the `aseprite` CLI (bypassing this project's Go/MCP layer): the SAME create+set-palette+draw sequence resolves the color correctly when done as three statements in one process, or when reloaded via `app.open()` within that same process, but incorrectly whenever the draw happens in a freshly-started `aseprite` process that only opens a previously-saved file (which is exactly how `--batch <file> --script ...` and pixel-mcp itself always operate).

Affects `draw_pixels`, `draw_line`, `draw_contour`, `draw_rectangle`, `draw_circle`, and `fill_area` whenever `use_palette` is false (the default) on an indexed sprite.

## Fix

`resolveExactPaletteColor` (`pkg/aseprite/lua_core.go`) resolves the color itself by reading the sprite's actual active palette at Lua runtime, bypassing Aseprite's unreliable resolution entirely:

- A fully-transparent color (alpha 0, e.g. a "paint transparent" `fill_area` call establishing a background) resolves directly to `spr.transparentColor`, since transparency is a designated index, not a color expected to exist in the palette.
- Any other color requires an exact match in the active palette and errors otherwise, so a caller drawing an approximate/non-locked color gets a clear error telling them to pass `use_palette=true` to snap to the nearest palette color, instead of a silently wrong pixel.

Wired into `DrawPixels` (`FormatColorWithPalette`) and `DrawLine`/`DrawContour`/`DrawRectangle`/`DrawCircle`/`FillArea` (`FormatColorWithPaletteForTool`).

## Testing

```
go build ./...            # clean
go vet ./...               # clean
go test ./...               # 627 passed
go test -tags=integration ./...   # 801 passed
```

Added `TestIntegration_IndexedMode_ExactColorResolution` (`pkg/tools/exact_palette_color_indexed_mode_bug_test.go`) with three subtests: exact match via `draw_rectangle`, exact match via `draw_pixels`, and an error on no match. Verified RED without the fix (all three fail/misbehave exactly as described above) and GREEN with it.

Updated two pre-existing unit tests that asserted the old, buggy literal output (`TestFormatColorWithPalette_NoPalette`, `TestLuaGenerator_DrawPixels`) to expect `resolveExactPaletteColor(...)` instead of a raw `Color(...)` call. Also fixed `TestIntegration_SetPalette_ThenApplyShading`, which drew an approximate "mid-tone" color with `use_palette=false` even though that color was never one of the locked palette's exact entries; it now correctly passes `use_palette=true` to snap it, which is what the test's own comment ("mid-tone") already implied.

## Notes

This is a separate, independent bug from the one I opened in #21 (`transparentColor` colliding with a real palette color after a resize) - unrelated root cause, unrelated code paths, no overlap in the fix. This branch is based directly on `main` so it applies cleanly regardless of #21's or #20's review status.
