### PR TITLE
fix: median cut blends distinct colors under imbalanced pixel frequency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **quantize_palette: median cut blends distinct colors under imbalanced pixel frequency**
+  - `MedianCutQuantization` split each bucket at the pixel-array midpoint
+    (`mid := len(pixels) / 2`), not at a boundary between distinct colors.
+    Pixel art typically has wildly imbalanced color frequency (a large
+    solid fill vastly outnumbering a 1-2px accent detail), so splitting at
+    the raw pixel-count median lands the cut inside the dominant color's
+    own run instead of between colors
+  - The dominant color got needlessly re-subdivided into near-duplicate
+    buckets while rare accent colors never got isolated into their own
+    bucket, and were instead averaged into a blended, off-palette hex
+    value - even when `target_colors` comfortably exceeded the number of
+    unique colors actually present, which should guarantee lossless
+    recovery
+  - Fixed by reducing to a frequency-weighted histogram of unique colors
+    before bucketing, so a split always falls between distinct colors;
+    the split point still favors common colors over rare ones by
+    cumulative pixel count, preserving normal median-cut reduction
+    behavior when `target_colors` is genuinely smaller than the number of
+    unique colors
+
 ## [0.5.0] - 2025-10-18
 
 ### Added

--- a/pkg/aseprite/quantization.go
+++ b/pkg/aseprite/quantization.go
@@ -110,14 +110,27 @@ func MedianCutQuantization(pixels []color.Color, targetColors int) []color.Color
 		return nil
 	}
 
+	// Reduce to a frequency histogram of unique colors before bucketing. A
+	// raw, duplicate-laden pixel list biases every split toward whatever
+	// large solid-fill color dominates the pixel count: cutting at the
+	// pixel-COUNT median of a mostly-one-color bucket lands the split point
+	// inside that same color's run (not at a boundary between colors), so
+	// the algorithm keeps re-subdividing the dominant fill while small
+	// accent regions (a 2px highlight next to a 200px fill, typical of
+	// pixel art) never get isolated into their own bucket and end up
+	// averaged into a blended, off-palette color instead. Splitting the
+	// unique-color histogram instead guarantees the split always falls
+	// between distinct colors, so targetColors >= the number of unique
+	// colors recovers every one of them exactly.
+	entries := buildColorHistogram(pixels)
+
 	// Ensure targetColors doesn't exceed number of unique colors
-	uniqueColors := countUniqueColorsInSlice(pixels)
-	if targetColors > uniqueColors {
-		targetColors = uniqueColors
+	if targetColors > len(entries) {
+		targetColors = len(entries)
 	}
 
-	// Create initial bucket with all pixels
-	buckets := []colorBucket{{pixels: pixels}}
+	// Create initial bucket with all unique colors
+	buckets := []colorBucket{{entries: entries}}
 
 	// Recursively split buckets until we have targetColors
 	for len(buckets) < targetColors {
@@ -132,7 +145,7 @@ func MedianCutQuantization(pixels []color.Color, targetColors int) []color.Color
 			}
 		}
 
-		// Stop if no bucket has any range (all colors are identical)
+		// Stop if no bucket has any range (all remaining buckets are single colors)
 		if maxRange == 0 {
 			break
 		}
@@ -154,22 +167,48 @@ func MedianCutQuantization(pixels []color.Color, targetColors int) []color.Color
 	return palette
 }
 
-// colorBucket represents a bucket of colors for median cut algorithm.
+// colorCount pairs a unique color with the number of pixels that had it.
+type colorCount struct {
+	c     color.Color
+	count int
+}
+
+// buildColorHistogram reduces a (possibly duplicate-laden) pixel slice to a
+// list of unique colors with their pixel counts, preserving first-seen order.
+func buildColorHistogram(pixels []color.Color) []colorCount {
+	index := make(map[uint32]int, len(pixels))
+	entries := make([]colorCount, 0, len(pixels))
+
+	for _, p := range pixels {
+		r, g, b, _ := p.RGBA()
+		key := (r&0xFF00)<<8 | (g & 0xFF00) | (b&0xFF00)>>8
+		if i, ok := index[key]; ok {
+			entries[i].count++
+			continue
+		}
+		index[key] = len(entries)
+		entries = append(entries, colorCount{c: p, count: 1})
+	}
+
+	return entries
+}
+
+// colorBucket represents a bucket of unique colors (with pixel counts) for the median cut algorithm.
 type colorBucket struct {
-	pixels []color.Color
+	entries []colorCount
 }
 
 // colorRange calculates the range of the bucket in RGB space.
 func (b *colorBucket) colorRange() float64 {
-	if len(b.pixels) == 0 {
+	if len(b.entries) == 0 {
 		return 0
 	}
 
 	var minR, minG, minB uint32 = 65535, 65535, 65535
 	var maxR, maxG, maxB uint32 = 0, 0, 0
 
-	for _, p := range b.pixels {
-		r, g, bl, _ := p.RGBA()
+	for _, e := range b.entries {
+		r, g, bl, _ := e.c.RGBA()
 		if r < minR {
 			minR = r
 		}
@@ -197,9 +236,15 @@ func (b *colorBucket) colorRange() float64 {
 	return rRange + gRange + bRange
 }
 
-// split splits the bucket along the dimension with the largest range.
+// split splits the bucket along the dimension with the largest range. The
+// split point is chosen where cumulative pixel count crosses half of the
+// bucket's total pixel mass (so common colors still get split priority over
+// rare ones, matching standard median-cut behavior), but since entries are
+// already unique colors, the split always falls BETWEEN distinct colors -
+// never through the middle of one - so a bucket of already-few unique colors
+// is never blended together by a split.
 func (b *colorBucket) split() (colorBucket, colorBucket) {
-	if len(b.pixels) < 2 {
+	if len(b.entries) < 2 {
 		return *b, colorBucket{}
 	}
 
@@ -207,8 +252,8 @@ func (b *colorBucket) split() (colorBucket, colorBucket) {
 	var minR, minG, minB uint32 = 65535, 65535, 65535
 	var maxR, maxG, maxB uint32 = 0, 0, 0
 
-	for _, p := range b.pixels {
-		r, g, bl, _ := p.RGBA()
+	for _, e := range b.entries {
+		r, g, bl, _ := e.c.RGBA()
 		if r < minR {
 			minR = r
 		}
@@ -233,57 +278,82 @@ func (b *colorBucket) split() (colorBucket, colorBucket) {
 	gRange := maxG - minG
 	bRange := maxB - minB
 
-	// Sort pixels by the dimension with largest range
-	pixels := make([]color.Color, len(b.pixels))
-	copy(pixels, b.pixels)
+	// Sort unique colors by the dimension with largest range
+	entries := make([]colorCount, len(b.entries))
+	copy(entries, b.entries)
 
 	if rRange >= gRange && rRange >= bRange {
 		// Sort by red
-		sort.Slice(pixels, func(i, j int) bool {
-			r1, _, _, _ := pixels[i].RGBA()
-			r2, _, _, _ := pixels[j].RGBA()
+		sort.Slice(entries, func(i, j int) bool {
+			r1, _, _, _ := entries[i].c.RGBA()
+			r2, _, _, _ := entries[j].c.RGBA()
 			return r1 < r2
 		})
 	} else if gRange >= bRange {
 		// Sort by green
-		sort.Slice(pixels, func(i, j int) bool {
-			_, g1, _, _ := pixels[i].RGBA()
-			_, g2, _, _ := pixels[j].RGBA()
+		sort.Slice(entries, func(i, j int) bool {
+			_, g1, _, _ := entries[i].c.RGBA()
+			_, g2, _, _ := entries[j].c.RGBA()
 			return g1 < g2
 		})
 	} else {
 		// Sort by blue
-		sort.Slice(pixels, func(i, j int) bool {
-			_, _, b1, _ := pixels[i].RGBA()
-			_, _, b2, _ := pixels[j].RGBA()
+		sort.Slice(entries, func(i, j int) bool {
+			_, _, b1, _ := entries[i].c.RGBA()
+			_, _, b2, _ := entries[j].c.RGBA()
 			return b1 < b2
 		})
 	}
 
-	// Split at median
-	mid := len(pixels) / 2
-	return colorBucket{pixels: pixels[:mid]}, colorBucket{pixels: pixels[mid:]}
+	// Split where cumulative pixel count crosses half the bucket's total
+	// mass, clamped so both sides always get at least one unique color.
+	total := 0
+	for _, e := range entries {
+		total += e.count
+	}
+	half := total / 2
+
+	cum := 0
+	splitIdx := 1
+	for i, e := range entries {
+		cum += e.count
+		if cum >= half {
+			splitIdx = i + 1
+			break
+		}
+	}
+	if splitIdx < 1 {
+		splitIdx = 1
+	}
+	if splitIdx > len(entries)-1 {
+		splitIdx = len(entries) - 1
+	}
+
+	return colorBucket{entries: entries[:splitIdx]}, colorBucket{entries: entries[splitIdx:]}
 }
 
-// average calculates the average color of the bucket.
+// average calculates the pixel-count-weighted average color of the bucket.
+// A single-entry bucket returns that entry's exact color unchanged.
 func (b *colorBucket) average() color.Color {
-	if len(b.pixels) == 0 {
+	if len(b.entries) == 0 {
 		return color.RGBA{R: 0, G: 0, B: 0, A: 255}
 	}
 
 	var sumR, sumG, sumB uint64
-	for _, p := range b.pixels {
-		r, g, bl, _ := p.RGBA()
-		sumR += uint64(r)
-		sumG += uint64(g)
-		sumB += uint64(bl)
+	var totalCount uint64
+	for _, e := range b.entries {
+		r, g, bl, _ := e.c.RGBA()
+		w := uint64(e.count)
+		sumR += uint64(r) * w
+		sumG += uint64(g) * w
+		sumB += uint64(bl) * w
+		totalCount += w
 	}
 
-	count := uint64(len(b.pixels))
 	return color.RGBA{
-		R: uint8((sumR / count) >> 8),
-		G: uint8((sumG / count) >> 8),
-		B: uint8((sumB / count) >> 8),
+		R: uint8((sumR / totalCount) >> 8),
+		G: uint8((sumG / totalCount) >> 8),
+		B: uint8((sumB / totalCount) >> 8),
 		A: 255,
 	}
 }
@@ -593,19 +663,6 @@ func CountUniqueColors(img image.Image, preserveTransparency bool) int {
 			packed := (r&0xFF00)<<8 | (g & 0xFF00) | (b&0xFF00)>>8
 			colorSet[packed] = true
 		}
-	}
-
-	return len(colorSet)
-}
-
-// countUniqueColorsInSlice counts unique colors in a slice of colors.
-func countUniqueColorsInSlice(pixels []color.Color) int {
-	colorSet := make(map[uint32]bool)
-
-	for _, p := range pixels {
-		r, g, b, _ := p.RGBA()
-		packed := (r&0xFF00)<<8 | (g & 0xFF00) | (b&0xFF00)>>8
-		colorSet[packed] = true
 	}
 
 	return len(colorSet)

--- a/pkg/aseprite/quantization_test.go
+++ b/pkg/aseprite/quantization_test.go
@@ -55,6 +55,66 @@ func TestMedianCutQuantization(t *testing.T) {
 	}
 }
 
+// TestMedianCutQuantization_ImbalancedFrequencyPreservesExactColors reproduces
+// the split-by-pixel-count bug: a bucket containing a large solid-fill color
+// alongside a handful of rare accent colors used to get bisected at the
+// pixel-count median, landing the split point inside the dominant color's own
+// run instead of at a boundary between colors. That blended rare accent
+// colors into off-palette hex values and could even drop them from the
+// palette entirely, even though targetColors comfortably exceeded the number
+// of unique colors present (which should guarantee lossless recovery).
+func TestMedianCutQuantization_ImbalancedFrequencyPreservesExactColors(t *testing.T) {
+	// Mirrors a typical pixel-art color distribution: a couple of large
+	// fills (many samples) plus several tiny accent regions (1-2 samples).
+	pixels := make([]color.Color, 0, 320)
+	appendN := func(c color.Color, n int) {
+		for i := 0; i < n; i++ {
+			pixels = append(pixels, c)
+		}
+	}
+
+	tunicGreen := color.RGBA{R: 0x6A, G: 0xBE, B: 0x30, A: 255}
+	skin := color.RGBA{R: 0xD9, G: 0xA0, B: 0x66, A: 255}
+	outline := color.RGBA{R: 0x22, G: 0x20, B: 0x34, A: 255}
+	highlight := color.RGBA{R: 0x99, G: 0xE5, B: 0x50, A: 255}
+	buckle := color.RGBA{R: 0xFB, G: 0xF2, B: 0x36, A: 255}
+
+	appendN(tunicGreen, 200)
+	appendN(skin, 90)
+	appendN(outline, 20)
+	appendN(highlight, 2)
+	appendN(buckle, 2)
+
+	want := map[color.RGBA]bool{
+		tunicGreen: true, skin: true, outline: true, highlight: true, buckle: true,
+	}
+
+	// Target far exceeds the 5 unique colors present, so every one of them
+	// must come back exactly - no blending, no duplicates, no drops.
+	palette := MedianCutQuantization(pixels, 32)
+
+	if len(palette) != len(want) {
+		t.Fatalf("MedianCutQuantization() returned %d colors, want %d (one bucket per unique input color): %v",
+			len(palette), len(want), palette)
+	}
+
+	seen := make(map[color.RGBA]bool, len(palette))
+	for _, c := range palette {
+		rgba, ok := c.(color.RGBA)
+		if !ok {
+			r, g, b, a := c.RGBA()
+			rgba = color.RGBA{R: uint8(r >> 8), G: uint8(g >> 8), B: uint8(b >> 8), A: uint8(a >> 8)}
+		}
+		if !want[rgba] {
+			t.Errorf("palette contains %+v, which is not one of the 5 exact input colors (blended/off-palette result)", rgba)
+		}
+		if seen[rgba] {
+			t.Errorf("palette contains duplicate entry %+v (a unique color's bucket was split into two near-identical averages)", rgba)
+		}
+		seen[rgba] = true
+	}
+}
+
 func TestOctreeQuantization(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/pkg/tools/quantize_palette_imbalanced_frequency_bug_test.go
+++ b/pkg/tools/quantize_palette_imbalanced_frequency_bug_test.go
@@ -1,0 +1,165 @@
+//go:build integration
+// +build integration
+
+package tools
+
+import (
+	"context"
+	"image/png"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/willibrandon/pixel-mcp/internal/testutil"
+	"github.com/willibrandon/pixel-mcp/pkg/aseprite"
+)
+
+// TestIntegration_QuantizePalette_ImbalancedFrequencyPreservesExactColors
+// reproduces the median-cut split-by-pixel-count bug end to end through the
+// real quantize_palette pipeline: export sprite -> aseprite.QuantizePalette
+// (Go clustering) -> ApplyQuantizedPalette (Lua, converts to indexed).
+//
+// The bug: MedianCutQuantization's bucket split picked the pixel-array
+// midpoint (mid := len(pixels) / 2) as the split point, not a boundary
+// between distinct colors. A typical pixel-art sprite has wildly imbalanced
+// color frequency - large solid fills (skin, clothing) vastly outnumber
+// small accent details (a 1-2px highlight or buckle) - so splitting at the
+// raw pixel-count median lands the cut inside the dominant fill color's own
+// run instead of between colors. The dominant color gets needlessly
+// re-subdivided into near-duplicate buckets while rare accent colors never
+// get isolated into their own bucket and are averaged into a blended,
+// off-palette hex value instead, even when target_colors comfortably
+// exceeds the number of unique colors actually present (which should
+// guarantee lossless recovery).
+//
+// This is the exact shape that surfaced the bug on a real 32x32 hero sprite:
+// a ~200px tunic fill, a ~90px skin fill, a thin outline, and 2px highlight/
+// buckle accents.
+func TestIntegration_QuantizePalette_ImbalancedFrequencyPreservesExactColors(t *testing.T) {
+	cfg := testutil.LoadTestConfig(t)
+	client := aseprite.NewClient(cfg.AsepritePath, cfg.TempDir, 30*time.Second)
+	gen := aseprite.NewLuaGenerator()
+	ctx := context.Background()
+
+	spritePath := testutil.TempSpritePath(t, "test-quantize-imbalanced.aseprite")
+	createScript := gen.CreateCanvas(32, 32, aseprite.ColorModeRGB, spritePath)
+	if _, err := client.ExecuteLua(ctx, createScript, ""); err != nil {
+		t.Fatalf("Failed to create canvas: %v", err)
+	}
+
+	tunicGreen := aseprite.Color{R: 0x6A, G: 0xBE, B: 0x30, A: 255}
+	skin := aseprite.Color{R: 0xD9, G: 0xA0, B: 0x66, A: 255}
+	outline := aseprite.Color{R: 0x22, G: 0x20, B: 0x34, A: 255}
+	highlight := aseprite.Color{R: 0x99, G: 0xE5, B: 0x50, A: 255}
+	buckle := aseprite.Color{R: 0xFB, G: 0xF2, B: 0x36, A: 255}
+
+	var pixels []aseprite.Pixel
+	add := func(x, y int, c aseprite.Color) {
+		pixels = append(pixels, aseprite.Pixel{Point: aseprite.Point{X: x, Y: y}, Color: c})
+	}
+	for y := 11; y < 21; y++ { // tunic: 20 x 10 = 200px
+		for x := 6; x < 26; x++ {
+			add(x, y, tunicGreen)
+		}
+	}
+	for y := 4; y < 10; y++ { // skin: 16 x 6 = 96px
+		for x := 6; x < 22; x++ {
+			add(x, y, skin)
+		}
+	}
+	for x := 6; x < 26; x++ { // outline: 20px
+		add(x, 2, outline)
+	}
+	add(15, 14, highlight) // 2px accent
+	add(16, 14, highlight)
+	add(15, 20, buckle) // 2px accent
+	add(16, 20, buckle)
+
+	drawScript := gen.DrawPixels("Layer 1", 1, pixels, false)
+	if _, err := client.ExecuteLua(ctx, drawScript, spritePath); err != nil {
+		t.Fatalf("Failed to draw pixels: %v", err)
+	}
+
+	// Real pipeline: export to PNG, quantize in Go, apply via Lua - matches
+	// pkg/tools/quantization.go's actual quantize_palette tool flow.
+	tempPNG := filepath.Join(t.TempDir(), "sprite.png")
+	exportScript := gen.ExportSprite(tempPNG, 0)
+	if _, err := client.ExecuteLua(ctx, exportScript, spritePath); err != nil {
+		t.Fatalf("Failed to export sprite: %v", err)
+	}
+	imgFile, err := os.Open(tempPNG)
+	if err != nil {
+		t.Fatalf("Failed to open exported PNG: %v", err)
+	}
+	defer imgFile.Close()
+	img, err := png.Decode(imgFile)
+	if err != nil {
+		t.Fatalf("Failed to decode PNG: %v", err)
+	}
+
+	// target_colors (32) comfortably exceeds the 5 unique colors present, so
+	// every one of them must survive quantization exactly.
+	palette, originalColors, err := aseprite.QuantizePalette(img, 32, "median_cut", true)
+	if err != nil {
+		t.Fatalf("QuantizePalette failed: %v", err)
+	}
+
+	want := map[string]bool{
+		"#00000000": true, "#6ABE30": true, "#D9A066": true, "#222034": true,
+		"#99E550": true, "#FBF236": true,
+	}
+	if len(palette) != len(want) {
+		t.Fatalf("BUG CONFIRMED: QuantizePalette(target=32) returned %d colors from %d unique input colors, want %d (lossless recovery): %v",
+			len(palette), originalColors, len(want), palette)
+	}
+	for _, c := range palette {
+		if !want[c] {
+			t.Errorf("BUG CONFIRMED: palette contains %s, not one of the 6 exact input colors (blended/off-palette result)", c)
+		}
+	}
+
+	applyScript := gen.ApplyQuantizedPalette(palette, originalColors, "median_cut", true, false)
+	if _, err := client.ExecuteLua(ctx, applyScript, spritePath); err != nil {
+		t.Fatalf("Failed to apply quantized palette: %v", err)
+	}
+
+	getPixelsScript := gen.GetPixels("Layer 1", 1, 0, 0, 32, 32)
+	output, err := client.ExecuteLua(ctx, getPixelsScript, spritePath)
+	if err != nil {
+		t.Fatalf("Failed to get pixels after conversion: %v", err)
+	}
+	got, err := testutil.ParsePixelData(output)
+	if err != nil {
+		t.Fatalf("Failed to parse pixel data: %v", err)
+	}
+	pixelAt := make(map[[2]int]string, len(got))
+	for _, p := range got {
+		pixelAt[[2]int{p.X, p.Y}] = p.Color
+	}
+
+	wantPixels := map[[2]int]string{
+		{0, 0}:   "#00000000",
+		{10, 15}: "#6ABE30FF",
+		{10, 6}:  "#D9A066FF",
+		{10, 2}:  "#222034FF",
+		{15, 14}: "#99E550FF",
+		{15, 20}: "#FBF236FF",
+	}
+	for pos, want := range wantPixels {
+		got, ok := pixelAt[pos]
+		if want == "#00000000" {
+			if ok && got != "#00000000" {
+				t.Errorf("BUG CONFIRMED: pixel %v should be transparent, got opaque %q", pos, got)
+			}
+			continue
+		}
+		if !ok {
+			t.Errorf("BUG CONFIRMED: pixel %v (want %s) missing from converted sprite", pos, want)
+			continue
+		}
+		if got != want {
+			t.Errorf("BUG CONFIRMED: pixel %v = %q, want %q", pos, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Bug

`MedianCutQuantization` split each bucket at the pixel-array midpoint (`mid := len(pixels) / 2`), not at a boundary between distinct colors. Pixel art typically has wildly imbalanced color frequency (a large solid fill vastly outnumbering a 1-2px accent detail), so splitting at the raw pixel-count median lands the cut inside the dominant color's own run instead of between colors.

The dominant color got needlessly re-subdivided into near-duplicate buckets while rare accent colors never got isolated into their own bucket, and were instead averaged into a blended, off-palette hex value - even when `target_colors` comfortably exceeded the number of unique colors actually present, which should guarantee lossless recovery.

On a 32x32 sprite with a ~200px tunic fill, ~90px skin fill, a thin outline, and 2px highlight/buckle accents, quantizing to `target_colors=32` (13 unique colors present) returned colors that did not exist anywhere in the source image.

## Fix

Reduce to a frequency-weighted histogram of unique colors before bucketing, so a split always falls between distinct colors. The split point still favors common colors over rare ones by cumulative pixel count, preserving normal median-cut reduction behavior when `target_colors` is genuinely smaller than the number of unique colors.

## Investigation note

I initially suspected a second bug in `ApplyQuantizedPalette`/`ChangePixelFormat` (pixels resolving to the wrong palette index, transparency lost on conversion to indexed mode). I verified via `aseprite --batch` scripts and full end-to-end integration tests (Go clustering -> Lua apply -> `get_pixels`) that `ChangePixelFormat` correctly honors a palette set immediately before it runs, in both the lossless (`target_colors >= unique colors`) and genuine lossy-reduction cases. The apparent scrambling in my initial hand-written repro script was caused by omitting the existing `ReassertIndexedTransparentColor()` call, not a new bug, so no change was needed in that file.

## Testing

- `go test ./...`: all passing
- `go test -tags=integration ./...`: pre-existing suite passing, plus the new regression test
- Added `TestMedianCutQuantization_ImbalancedFrequencyPreservesExactColors` (`pkg/aseprite/quantization_test.go`): pure-Go unit test, no Aseprite needed, guards the fix in CI
- Added `TestIntegration_QuantizePalette_ImbalancedFrequencyPreservesExactColors` (`pkg/tools/quantize_palette_imbalanced_frequency_bug_test.go`): reproduces the exact hero-sprite shape end to end through the real `quantize_palette` pipeline (export -> Go quantize -> Lua apply -> `get_pixels`), checking both exact colors and transparency survive conversion to indexed mode. Verified RED without the fix (blended colors and wrong pixels, matching the originally observed corruption) and GREEN with it.